### PR TITLE
modify "form" to "from"

### DIFF
--- a/docs/mangle-administration/supported-deployment-models/advanced-cassandra-configuration.md
+++ b/docs/mangle-administration/supported-deployment-models/advanced-cassandra-configuration.md
@@ -71,8 +71,10 @@ port = 9042
 factory = cqlshlib.ssl.ssl_transport_factory
 
 [ssl]
-certfile = /cassandra/certs/fiaascocassandra_CLIENT.cer.pem
-# Optional, true by default
+
+certfile = /cassandra/certs/fiaascocassandra_CLIENT.cer.pem
+
+# Optional, true by default
 validate = false
 # Next 2 lines must be provided when require_client_auth = true in the cassandra.yaml file
 # userkey = /cassandra/certs/fiaascocassandra_CLIENT.key.pem
@@ -97,7 +99,7 @@ Attaching the required files which help to enable the authentication and ssl in 
 
 {% file src="../../.gitbook/assets/generatedbcert.sh" caption="Certificate Generation Script" %}
 
-To download the Cassandra client as DevCenter form [DevCenter](https://academy.datastax.com/downloads).
+To download the Cassandra client as DevCenter from [DevCenter](https://academy.datastax.com/downloads).
 
 **To Create Multi-Node Cassandra cluster**
 


### PR DESCRIPTION
I think it should be "To download the Cassandra client as DevCenter from [DevCenter](https://academy.datastax.com/downloads).", but not "To download the Cassandra client as DevCenter form [DevCenter](https://academy.datastax.com/downloads).".