### PR TITLE
Correct Step 4 Word Tense

### DIFF
--- a/docs/sre-developers-and-users/adding-endpoint-groups.md
+++ b/docs/sre-developers-and-users/adding-endpoint-groups.md
@@ -16,7 +16,7 @@ This will allow you to
 1. Login as an user with read and write privileges to Mangle.
 2. Navigate to Endpoint tab ---&gt; Endpoints ---&gt; Endpoint Groups.
 3. Click on ![](../.gitbook/assets/add_button%20%281%29.png) .
-4. Enter a name, group type \(only remote machines are currently supported\), a list or two or more existing endpoints, tags \(refers to additional tags that should be send to the enabled metric provider to uniquely identify the endpoint group\) and click on **Test Connection**.
+4. Enter a name, group type \(only remote machines are currently supported\), a list or two or more existing endpoints, tags \(refers to additional tags that should be sent to the enabled metric provider to uniquely identify the endpoint group\) and click on **Test Connection**.
 5. If **Test Connection** succeeds click on **Submit**.
 6. A success message is displayed and the table for Endpoints will be updated with the new entry.
 7. Edit, Delete, Enable and Disable actions are available for all added Endpoint groups.


### PR DESCRIPTION

Change the word "send" to "sent" to use proper tense in documentation step 4 under Endpoint Groups.