### PR TITLE
Updating Xstream and Spring versions to fix security issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,11 @@
 		<testng.version>6.11</testng.version>
 		<com.fasterxml.jackson.datatype.version>2.5.1</com.fasterxml.jackson.datatype.version>
 		<checkstyle.version>3.0.0</checkstyle.version>
-		<spring.security.core.version>5.2.10.RELEASE</spring.security.core.version>
-		<spring.security.web.version>5.2.10.RELEASE</spring.security.web.version>
+		<spring.security.core.version>5.3.11.RELEASE</spring.security.core.version>
+		<spring.security.web.version>5.3.11.RELEASE</spring.security.web.version>
 		<mvn.surefire.plugin.version>2.22.1</mvn.surefire.plugin.version>
 		<jacoco.ant.version>0.7.8</jacoco.ant.version>
-		<com.thoughtworks.xstream.version>1.4.17</com.thoughtworks.xstream.version>
+		<com.thoughtworks.xstream.version>1.4.18</com.thoughtworks.xstream.version>
 		<junit.jupiter.version>5.3.1</junit.jupiter.version>
 		<docker-java.version>3.1.0</docker-java.version>
 		<com.jcraft.jsch.version>0.1.54</com.jcraft.jsch.version>


### PR DESCRIPTION
Updating following versions in root pom to fix security issues:
com.thoughtworks.xstream.version to 1.4.18
 spring.security.core.version to 5.3.11.RELEASE
spring.security.web.version 5.3.11.RELEASE