### PR TITLE
Log4j vulnerability fix for Mangle

### DIFF
--- a/mangle-utils/pom.xml
+++ b/mangle-utils/pom.xml
@@ -29,6 +29,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<apache-log4j-api.version>2.17.0</apache-log4j-api.version>
 	</properties>
 
 	<dependencies>
@@ -196,7 +197,19 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
+			<version>${apache-log4j-api.version}</version>
+		     <exclusions>
+			        <exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-api</artifactId>
+				</exclusion>
+		     </exclusions>
 		</dependency>
+		<dependency>
+                    <groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${apache-log4j-api.version}</version>
+		    </dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-ec2</artifactId>

--- a/mangle-vcenter-adapter-models/pom.xml
+++ b/mangle-vcenter-adapter-models/pom.xml
@@ -71,8 +71,8 @@
             <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+	         <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>ru.yandex.qatools.allure</groupId>

--- a/mangle-vcenter-adapter/pom.xml
+++ b/mangle-vcenter-adapter/pom.xml
@@ -102,8 +102,8 @@
 			<artifactId>httpclient</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
+		     <groupId>org.apache.logging.log4j</groupId>
+		      <artifactId>log4j-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.springfox</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 		<hazelcast-kubernetes.version>1.3.1</hazelcast-kubernetes.version>
 		<org.json.version>20180130</org.json.version>
 		<net.jpountz.lz4.version>1.3.0</net.jpountz.lz4.version>
-		<log4j.version>1.2.17</log4j.version>
+		<log4j.version>2.17.0</log4j.version>
 		<avro-version>1.10.2</avro-version>
 		<asynchttpclient.version>2.12.3</asynchttpclient.version>
 		<netty.version>4.1.68.Final</netty.version>
@@ -822,20 +822,20 @@
 				<version>${org.json.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>log4j</groupId>
-				<artifactId>log4j</artifactId>
-				<version>${log4j.version}</version>
-				<scope>compile</scope>
-				<exclusions>
-					<exclusion>
-						<artifactId>tomcat-annotations-api</artifactId>
-						<groupId>org.apache.tomcat</groupId>
-					</exclusion>
-					<exclusion>
-						<artifactId>commons-logging</artifactId>
-						<groupId>commons-logging</groupId>
-					</exclusion>
-				</exclusions>
+		           <groupId>org.apache.logging.log4j</groupId>
+			   <artifactId>log4j-core</artifactId>
+			   <version>${log4j.version}</version>
+			   <exclusions>
+				<exclusion>
+				     <groupId>org.apache.logging.log4j</groupId>
+				     <artifactId>log4j-api</artifactId>
+				</exclusion>
+			  </exclusions>
+		      </dependency>
+		      <dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${log4j.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.allbegray</groupId>

--- a/resiliency-score-calculator/pom.xml
+++ b/resiliency-score-calculator/pom.xml
@@ -23,7 +23,7 @@
 		<maven-compiler.version>3.7.0</maven-compiler.version>
 		<spring.framework.version>5.3.9</spring.framework.version>
 		<lombok.version>1.18.2</lombok.version>
-		<apache-log4j-api.version>2.14.1</apache-log4j-api.version>
+		<apache-log4j-api.version>2.17.0</apache-log4j-api.version>
 		<log4j.version>1.2.17</log4j.version>
 		<javax.mail.version>1.4</javax.mail.version>
 		<gson.version>2.3.1</gson.version>


### PR DESCRIPTION
Description:
        Upgrading org.apache.logging.log4j to 2.17.0
       Upgrading com.thoughtworks.xstream.xstream to 1.4.18