### PR TITLE
Adding back xstream dependency and excluding dependencies with vulnerablities

### DIFF
--- a/mangle-utils/pom.xml
+++ b/mangle-utils/pom.xml
@@ -63,6 +63,10 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>com.thoughtworks.xstream</groupId>
+			<artifactId>xstream</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-oxm</artifactId>
 		</dependency>

--- a/mangle-vcenter-adapter-models/pom.xml
+++ b/mangle-vcenter-adapter-models/pom.xml
@@ -54,6 +54,10 @@
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-base</artifactId>
         </dependency>
+	 <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>

--- a/mangle-vcenter-adapter/pom.xml
+++ b/mangle-vcenter-adapter/pom.xml
@@ -78,6 +78,10 @@
 			<artifactId>lombok</artifactId>
 		</dependency>
 		<dependency>
+                  <groupId>com.thoughtworks.xstream</groupId>
+                 <artifactId>xstream</artifactId>
+              </dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-oxm</artifactId>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<maven-compiler.version>3.7.0</maven-compiler.version>
 		<spring.boot.version>2.2.13.RELEASE</spring.boot.version>
 		<spring.cloud.version>2.0.2.RELEASE</spring.cloud.version>
-		<springframework.version>5.2.23.RELEASE</springframework.version>
+		<springframework.version>5.1.20.RELEASE</springframework.version>
 		<kotlin-stdlib.version>1.6.0</kotlin-stdlib.version>
 		<springframework-plugin.version>1.2.0.RELEASE</springframework-plugin.version>
 		<swagger-version>2.9.2</swagger-version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
 		<spring.security.web.version>5.3.11.RELEASE</spring.security.web.version>
 		<mvn.surefire.plugin.version>2.22.1</mvn.surefire.plugin.version>
 		<jacoco.ant.version>0.7.8</jacoco.ant.version>
+		<com.thoughtworks.xstream.version>1.4.20</com.thoughtworks.xstream.version>
 		<junit.jupiter.version>5.3.1</junit.jupiter.version>
 		<docker-java.version>3.1.0</docker-java.version>
 		<com.jcraft.jsch.version>0.1.54</com.jcraft.jsch.version>
@@ -443,6 +444,25 @@
 				<groupId>com.fasterxml.jackson.module</groupId>
 				<artifactId>jackson-module-parameter-names</artifactId>
 				<version>${jackson.databind.version}</version>
+			</dependency>
+				<dependency>
+				<groupId>com.thoughtworks.xstream</groupId>
+				<artifactId>xstream</artifactId>
+				<version>${com.thoughtworks.xstream.version}</version>
+			    <exclusions>
+				<exclusion>
+				  <groupId>dom4j</groupId>
+                                  <artifactId>dom4j</artifactId>
+			        </exclusion>
+			       <exclusion>
+				  <groupId>org.codehaus.jettison</groupId>
+                                  <artifactId>jettison</artifactId>
+			       </exclusion>
+			       <exclusion>
+				 <groupId>org.jdom</groupId>
+                                 <artifactId>jdom</artifactId>
+				</exclusion>
+			   </exclusions>
 			</dependency>
 			<dependency>
 				<groupId>io.springfox</groupId>


### PR DESCRIPTION
Reverting the change of removing xstream dependency and excluding dependencies with vulnerablities associated with xstream dependency.
Also reverting back the commit: 26fdbf4 which bumped up the springframework dependencies.